### PR TITLE
Feature/20 document layout

### DIFF
--- a/app/src/main/java/com/recodream_aos/recordream/presentation/document/DocumentActivity.kt
+++ b/app/src/main/java/com/recodream_aos/recordream/presentation/document/DocumentActivity.kt
@@ -1,12 +1,77 @@
 package com.recodream_aos.recordream.presentation.document
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import com.recodream_aos.recordream.R
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.tabs.TabLayoutMediator
+import com.recodream_aos.recordream.databinding.ActivityDocumentBinding
+import com.recodream_aos.recordream.util.CustomDialog
+import com.recodream_aos.recordream.util.RecordreamMapping
 
 class DocumentActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityDocumentBinding
+
+    // 더보기 바텀시트, 삭제 확인창 변수
+    private val documentBottomSheetFragment = DocumentBottomSheetFragment()
+    private lateinit var dialog: CustomDialog
+
+    // 선택한 카드 정보 반영해서 불러오기 위해 변수 설정
+    private val recordreamMapping = RecordreamMapping()
+
+//    나중에 뷰모델 써서 불러올 예정
+//    private val viewModel by viewModels<DocumentViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_document)
+        binding = ActivityDocumentBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+//        나중에 수정해서 추가 예정
+//        val recordId = intent.getStringExtra("id")?: error("need record Id")
+
+        initAdapter()
+        initTabLayout()
+        initCloseButton()
+//        initNetwork(recordId)
+//        observeData()
+
+        binding.ivDotsMore.setOnClickListener { createBottom() }
     }
+
+    private fun createBottom() {
+        documentBottomSheetFragment.show(supportFragmentManager, documentBottomSheetFragment.tag)
+    }
+
+    private fun initAdapter() {
+        val documentViewPagerAdapter = DocumentViewPagerAdapter(this)
+        binding.vpDocument.adapter = documentViewPagerAdapter
+    }
+
+    // 탭 이름 적용 없이 인디케이터만 움직이게 수정 예정
+    private fun initTabLayout() {
+        val tabLabel = listOf("나의 꿈 기록", "노트")
+
+        TabLayoutMediator(binding.tlDocument, binding.vpDocument) { tab, position ->
+            tab.text = tabLabel[position]
+        }.attach()
+    }
+
+    private fun initCloseButton() {
+        binding.ivDocumentClose.setOnClickListener {
+            finish()
+        }
+    }
+//
+//    private fun initNetwork(id:String){
+//        viewModel.getData(id)
+//    }
+
+//    private fun applyData(response: ResponseDocumentDreamRecord) {
+//    }
+//
+// private fun observeData(){
+//     viewModel.documentResponse.observe(this){
+//         applyData(it)
+//     }
+// }
 }

--- a/app/src/main/java/com/recodream_aos/recordream/presentation/document/DocumentBottomSheetFragment.kt
+++ b/app/src/main/java/com/recodream_aos/recordream/presentation/document/DocumentBottomSheetFragment.kt
@@ -30,6 +30,7 @@ class DocumentBottomSheetFragment : BottomSheetDialogFragment() {
         initDialog()
         clickShare()
         clickEvent()
+        clickCancel()
         return binding.root
     }
 
@@ -54,6 +55,12 @@ class DocumentBottomSheetFragment : BottomSheetDialogFragment() {
         binding.tvDocumentBottomDelete.setOnClickListener {
             dialogDelete = CustomDialog(requireActivity())
             dialogDelete.showDeleteDialog(R.layout.document_delete_dialog)
+        }
+    }
+
+    private fun clickCancel() {
+        binding.btnDocumentBottomCancel.setOnClickListener {
+            dismiss()
         }
     }
 }

--- a/app/src/main/java/com/recodream_aos/recordream/presentation/document/DocumentViewPagerAdapter.kt
+++ b/app/src/main/java/com/recodream_aos/recordream/presentation/document/DocumentViewPagerAdapter.kt
@@ -1,0 +1,17 @@
+package com.recodream_aos.recordream.presentation.document
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class DocumentViewPagerAdapter(fragment: FragmentActivity) :
+    FragmentStateAdapter(fragment) {
+
+    override fun getItemCount(): Int = 2
+
+    override fun createFragment(position: Int): Fragment = when (position) {
+        0 -> DreamRecordFragment()
+        1 -> NoteFragment()
+        else -> throw Exception()
+    }
+}

--- a/app/src/main/res/layout/activity_document.xml
+++ b/app/src/main/res/layout/activity_document.xml
@@ -7,21 +7,21 @@
 
         <!--        <variable-->
         <!--            name="records"-->
-        <!--            type="and.org.recordream.data.remote.response.ResponseDetailDreamRecord" />-->
+        <!--            type="and.org.recordream.data.remote.response.ResponsedocumentDreamRecord" />-->
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/activity_detail"
+        android:id="@+id/activity_document"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".presentation.detail.DetailActivity">
+        tools:context=".presentation.document.documentActivity">
 
         <ImageView
-            android:id="@+id/iv_detail_dream_color"
+            android:id="@+id/iv_document_dream_color"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:scaleType="fitXY"
-            app:layout_constraintBottom_toTopOf="@id/tl_detail"
+            app:layout_constraintBottom_toTopOf="@id/tl_document"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -38,7 +38,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/tv_detail_page_name"
+            android:id="@+id/tv_document_page_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="기록 상세보기"
@@ -63,10 +63,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="47dp"
+            android:src="@drawable/feeling_l_joy"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_detail_page_name"
-            tools:src="@drawable/feeling_l_joy" />
+            app:layout_constraintTop_toBottomOf="@id/tv_document_page_name" />
 
         <TextView
             android:id="@+id/tv_record_date"
@@ -140,7 +140,7 @@
             tools:textColor="@color/white01_FFFFFF" />
 
         <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tl_detail"
+            android:id="@+id/tl_document"
             android:layout_width="0dp"
             android:layout_height="1dp"
             android:layout_marginTop="15dp"
@@ -158,14 +158,14 @@
             app:tabTextColor="@color/white02_80FFFFFF" />
 
         <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/vp_detail"
+            android:id="@+id/vp_document"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@color/dark01_02040F"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/tl_detail"
-            app:layout_constraintStart_toStartOf="@id/tl_detail"
-            app:layout_constraintTop_toBottomOf="@+id/tl_detail" />
+            app:layout_constraintEnd_toEndOf="@id/tl_document"
+            app:layout_constraintStart_toStartOf="@id/tl_document"
+            app:layout_constraintTop_toBottomOf="@+id/tl_document" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_dream_record.xml
+++ b/app/src/main/res/layout/fragment_dream_record.xml
@@ -42,7 +42,7 @@
                     android:layout_marginHorizontal="5dp"
                     android:layout_marginTop="12dp"
                     android:background="@drawable/rectangle_radius_8_document_record"
-                    android:visibility="gone"
+
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_dream_record_title">


### PR DESCRIPTION
## 👻 작업한 내용
브랜치 이름 제대로 안 보고 작업하고 보니 layout 브랜치였습니다..
작업 내용은 거의 document inflate입니다🥲
상세보기 뷰에서 바텀시트, 바텀시트의 취소 버튼, 삭제 버튼 눌렀을 때 뜨는 삭제 dialog, 창 닫기 버튼 등등 구현했습니다.
서버 연결이랑 관련된 것들은 주석 처리 해놓고 나중에 수정할 예정입니다.
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

## 🎤 PR Point
디자인 수정으로 이제 예전처럼 탭에 텍스트 적용할 필요 없이 인디케이터만 움직이면 되어서 코드를 수정하면 줄일 수 있을 것 같지만, 아직 그 부분은 주석만 적어놓았고 나중에 수정 예정입니다.
<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #20 
